### PR TITLE
Enhance information around usage of .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@ This project combines `inotifywait` from `inotify-tools` with Docker to watch fo
 For example, this image could be used in a docker-compose file to restart a container upon an update to an SSL certificate file, where the service is unable to handle this itself. In this case, you would configure the environment variable to monitor the certificate file.
 
 ## Example compose file
+This example has been created based upon the docker compose CLI v2.
+
 Set the file to monitor for changes as an environment variable.
 
-*(Alternatively, you can individually replace ${MONITOR_FILE} with suitable values.)*
+This can also be set in a `.env` file in the same directory as the compose file.
+
+***Note**: Environment variables set with `export` or another method take precedence over `.env`. Ensure to `unset MONITOR_FILE` if issues with `.env` are experienced.*
+
+You should always ensure the irestarter container is running following a `docker-compose up`.
+
+Alternatively, you can individually replace ${MONITOR_FILE} in the compose file with suitable values.
 ```
 MONITOR_FILE=/file/to/monitor.txt
 ```
@@ -22,7 +30,7 @@ version: "3"
 services:
   docker-irestarter:
     image: zetifi/docker-irestarter:latest
-    restart: always
+    restart: "no"
     volumes:
       - ${MONITOR_FILE}:${MONITOR_FILE}
       - /var/run/docker.sock:/var/run/docker.sock
@@ -44,7 +52,7 @@ version: "3"
 services:
   docker-irestarter:
     image: zetifi/docker-irestarter:latest
-    restart: always
+    restart: "no"
     volumes:
       - ${MONITOR_FILE}:${MONITOR_FILE}
       - /var/run/docker.sock:/var/run/docker.sock

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ -z $MONITOR_FILE ]]; then
+    echo "MONITOR_FILE can not be an empty string."
+    exit 1
+fi
+
 function process_restart() {
     if [[ $SIGHUP ]]; then
         container=$(docker ps --latest --quiet --filter "label=docker-irestarter-SIGHUP")


### PR DESCRIPTION
- Note this project is designed against compose CLI v2
- Information about .env precedence
- Example recommends to use default restart policy of "no"
- Added check at container startup to catch the small handful of cases where the container can be started without setting the monitor file variable, but the docker compose volume creation does not complain and catch the issue first. (If someone didn't use compose or set the volume config separately of the monitor file variable)