### PR TITLE
Bug fix and general improvements

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,23 +1,21 @@
-name: Publish Docker Image
+name: Publish container
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
-  docker-hub-push:
-    name: Push Docker image to Docker Hub
+  publish-ghcr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Docker meta
-        id: meta
+      - name: Gather metadata
+        id: metadata
         uses: docker/metadata-action@v4
         with:
-          images: zetifi/docker-irestarter
+          images: ghcr.io/zetifi/docker-irestarter
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -29,18 +27,20 @@ jobs:
         with:
           platforms: linux/arm64/v8,linux/amd64
 
-      - name: Log in to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.github_token }}
         
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, zetifi/docker-irestarter:latest
-          labels: ${{ steps.meta.outputs.labels }}
+          context: .
           platforms: linux/arm64/v8,linux/amd64
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}, ghcr.io/zetifi/docker-irestarter:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max          

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -18,6 +18,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: zetifi/docker-irestarter
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -34,5 +39,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: zetifi/docker-irestarter:latest
+          tags: ${{ steps.meta.outputs.tags }}, zetifi/docker-irestarter:latest
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64/v8,linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max          

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-test.log
-Dockerfile.example-service
-docker-compose.yml
+example/irestarter-test

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ version: "3"
 services:
   docker-irestarter:
     image: zetifi/docker-irestarter:latest
-    restart: "no"
+    restart: always
     volumes:
       - ${MONITOR_FILE}:${MONITOR_FILE}
       - /var/run/docker.sock:/var/run/docker.sock
@@ -43,27 +43,28 @@ services:
       - "docker-irestarter"
 ```
 
-### Alternate example
-Instead of restarting the container, it's possible to send a SIGHUP signal to a proccess within the container.
+### Send a Linux Signal instead of container restart
+Instead of restarting the container, it's possible to send a signal to a container.
+Refer to the [signal(7)](https://man7.org/linux/man-pages/man7/signal.7.html) man-page for a list of standard Linux signals.
 
-Note the different label applied to the target container and the additional environment variable added to the `docker-irestarter` container.
+Note the `SIGHUP` signal passsed as an environment variable to the `docker-irestarter` container.
 ```yml
 version: "3"
 services:
   docker-irestarter:
     image: zetifi/docker-irestarter:latest
-    restart: "no"
+    restart: always
     volumes:
       - ${MONITOR_FILE}:${MONITOR_FILE}
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - MONITOR_FILE=${MONITOR_FILE}
-      - SIGHUP=${SIGHUP_PROCESS}
+      - SIGNAL=SIGHUP
 
   example-service:
     ...
     labels:
-      - "docker-irestarter-SIGHUP"
+      - "docker-irestarter"
 ```
 <!--
 ### Publishing

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project combines `inotifywait` from `inotify-tools` with Docker to watch fo
 For example, this image could be used in a docker-compose file to restart a container upon an update to an SSL certificate file, where the service is unable to handle this itself. In this case, you would configure the environment variable to monitor the certificate file.
 
 ## Example compose file
+Read on, or [view an example project](example).
+
 This example has been created based upon the docker compose CLI v2.
 
 Set the file to monitor for changes as an environment variable.
@@ -66,48 +68,3 @@ services:
     labels:
       - "docker-irestarter"
 ```
-<!--
-### Publishing
-
-Notes for building and publishing
-```bash
-# For publish:
-docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag zetifi/docker-irestarter:latest .
-
-# For dev:
-docker build --tag zetifi/docker-irestarter:latest .                                                    
-```
-
-### Full working example
-
-Dockerfile.example-service
-```yml
-FROM alpine:latest
-
-RUN touch example.log
-
-CMD ["tail", "-f", "example.log"]
-```
-
-docker-compose.yml
-```yml
-version: "3"
-services:
-  docker-irestarter:
-    build:
-      context: .
-    restart: always
-    volumes:
-      - ${MONITOR_FILE}:${MONITOR_FILE}
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - MONITOR_FILE=${MONITOR_FILE}
-
-  example-service:
-    build:
-      context: .
-      dockerfile: Dockerfile.example-service
-    labels:
-      - "docker-irestarter"
-```
--->

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,13 +6,13 @@ if [[ -z $MONITOR_FILE ]]; then
     exit 1
 fi
 
+container=$(docker ps --latest --quiet --filter "label=docker-irestarter")
+if [[ -z $container ]]; then
+    echo "No docker container with 'docker-irestarter' label could be found"
+    exit 1
+fi 
+
 function process_restart() {
-
-    container=$(docker ps --latest --quiet --filter "label=docker-irestarter")
-
-    if [[ $SIGNAL ]]; then
-        docker kill --signal=$SIGNAL $container
-        echo "docker kill signal $SIGNAL sent to $container"
     else
         docker restart $container
         echo "docker restart sent to $container"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,12 +7,13 @@ if [[ -z $MONITOR_FILE ]]; then
 fi
 
 function process_restart() {
-    if [[ $SIGHUP ]]; then
-        container=$(docker ps --latest --quiet --filter "label=docker-irestarter-SIGHUP")
-        docker kill --signal=SIGHUP $container
-        echo "SIGHUP sent to $container for proccess $SIGHUP"
+
+    container=$(docker ps --latest --quiet --filter "label=docker-irestarter")
+
+    if [[ $SIGNAL ]]; then
+        docker kill --signal=$SIGNAL $container
+        echo "docker kill signal $SIGNAL sent to $container"
     else
-        container=$(docker ps --latest --quiet --filter "label=docker-irestarter")
         docker restart $container
         echo "docker restart sent to $container"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 function process_restart() {
     if [[ $SIGHUP ]]; then
         container=$(docker ps --latest --quiet --filter "label=docker-irestarter-SIGHUP")
-        docker exec $container killall -SIGHUP $SIGHUP
+        docker kill --signal=SIGHUP $container
         echo "SIGHUP sent to $container for proccess $SIGHUP"
     else
         container=$(docker ps --latest --quiet --filter "label=docker-irestarter")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+CONTAINER_LABEL=docker-irestarter
 
 if [[ -z $MONITOR_FILE ]]; then
     echo "MONITOR_FILE can not be an empty string."
     exit 1
 fi
 
-container=$(docker ps --latest --quiet --filter "label=docker-irestarter")
-if [[ -z $container ]]; then
-    echo "No docker container with 'docker-irestarter' label could be found"
+CONTAINER=$(docker ps --latest --quiet --filter "label=$CONTAINER_LABEL")
+if [[ -z $CONTAINER ]]; then
+    echo "No docker container with '$CONTAINER_LABEL' label could be found"
     exit 1
 fi 
 
 function process_restart() {
+    if [[ -n $SIGNAL ]]; then
+        docker kill --signal=$SIGNAL $CONTAINER
+        echo "docker kill signal $SIGNAL sent to $CONTAINER"
     else
-        docker restart $container
-        echo "docker restart sent to $container"
+        docker restart $CONTAINER
+        echo "docker restart sent to $CONTAINER"
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ function process_restart() {
     fi
 }
 
-inotifywait --monitor --event close_write $MONITOR_FILE | while read; do process_restart; done
+inotifywait --monitor --recursive --event close_write $MONITOR_FILE | while read; do process_restart; done

--- a/example/Dockerfile.example-service
+++ b/example/Dockerfile.example-service
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN touch example.log
+
+CMD ["tail", "-f", "example.log"]

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  docker-irestarter:
+    image: zetifi/docker-irestarter:latest
+    restart: always
+    volumes:
+      - ./irestarter-test/live:/etc/letsencrypt:ro # Local file or directory to monitor for changes
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - MONITOR_FILE=/etc/letsencrypt
+      - SIGNAL=SIGHUP # Optional signal to pass to main container process, rather than restarting the container
+
+  example-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.example-service
+    labels:
+      - "docker-irestarter" # Required label for irestarter to target this container


### PR DESCRIPTION
I've added a missing recursion flag to the `inotifywait` command, this is key to monitor files in subdirectories if a directory is specified rather than a file. I inadvertently had only been testing locally within the main directory and missed this option.

Also:
- Updated to use the `docker kill` command to send signals via the host machine, rather than exec into the target container
- Simplified usability by condensing the target label back into a single docker label to specify the target container
- Added ability to pass any valid Linux signal to the target container, rather than only SIGHUP
- Added check if no target container is found at startup
- Minor refactoring for readability
- Improved GitHub action tagging of published container
  - Moved from Dockerhub to GitHub Container Registry
  - Added versioning
- Added full example compose file and dummy service